### PR TITLE
Finish phasing out dimID in favor of dimStrings

### DIFF
--- a/src/main/java/vazkii/ambience/SongLoader.java
+++ b/src/main/java/vazkii/ambience/SongLoader.java
@@ -97,7 +97,6 @@ public final class SongLoader {
 						continue;
 
 					String keyType = tokens[0];
-					int dimID = tryParse(tokens[1], 0);
 					if (keyType.equals("event")) {
 						String event = tokens[1];
 						
@@ -158,11 +157,11 @@ public final class SongLoader {
 						if(tokens.length>2) 							
 						{
 							event=tokens[2];
-							SongPicker.eventMap.put(event+"\\"+ dimID, props.getProperty(s).split(","));
+							SongPicker.eventMap.put(event+"\\"+ tokens[1], props.getProperty(s).split(","));
 						}
 						else
 						{
-							SongPicker.eventMap.put("dim" + dimID, props.getProperty(s).split(","));
+							SongPicker.eventMap.put("dim" + tokens[1], props.getProperty(s).split(","));
 						}
 					}
 


### PR DESCRIPTION
this fixes all 1.16 issues with dimension ambience.properties configs. the wiki will need to be updated to mention that in order to work, users will have to configure ambience.properties in the following way.
OLD: dimension.-1=
NEW: dimension.the_end=